### PR TITLE
Fix document put endpoint

### DIFF
--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -63,26 +63,73 @@ namespace BUILD.ING.Controllers
         // GET: api/Buildings
         // Returns a list of all buildings
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<Building>>> GetBuildings()
+        public async Task<ActionResult<IEnumerable<BuildingDto>>> GetBuildings()
         {
-            //We can apply later group-based filtering here
-            return await _context.Buildings.ToListAsync().ConfigureAwait(false);
+            var buildings = await _context.Buildings.ToListAsync().ConfigureAwait(false);
+            var buildingIds = buildings.Select(b => b.BuildingId).ToList();
+            var documents = _context.Documents
+                .Where(d => d.BuildingId.HasValue && buildingIds.Contains(d.BuildingId.Value))
+                .Select(d => new { d.BuildingId, d.DocumentId, d.Title })
+                .ToList();
+            var orgMap = _context.Organizations.ToDictionary(o => o.OrganizationId, o => o.Name);
+            var dtos = buildings.Select(b => new BuildingDto
+            {
+                BuildingId = b.BuildingId,
+                Name = b.Name,
+                StreetName = b.StreetName,
+                HouseNumber = b.HouseNumber,
+                PostalCode = b.PostalCode,
+                City = b.City,
+                Country = b.Country,
+                ConstructionYear = b.ConstructionYear,
+                TotalArea = b.TotalArea,
+                Floors = b.Floors,
+                Description = b.Description,
+                Coordinates = b.Coordinates?.ToString(),
+                CreatedAt = b.CreatedAt,
+                UpdatedAt = b.UpdatedAt,
+                OrganizationId = b.OrganizationId,
+                OrganizationName = orgMap.ContainsKey(b.OrganizationId) ? orgMap[b.OrganizationId] : null,
+                Documents = documents.Where(d => d.BuildingId == b.BuildingId)
+                    .Select(d => new KeyValuePair<int, string>(d.DocumentId, d.Title)).ToList()
+            }).ToList();
+            return Ok(dtos);
         }
 
         // GET: api/Buildings/{id}
         // Returns a single building by ID
         [HttpGet("{id}")]
-        public async Task<ActionResult<Building>> GetBuilding(int id)
+        public async Task<ActionResult<BuildingDto>> GetBuilding(int id)
         {
-            var building = await _context.Buildings
-                .Include(b => b.Documents)
-                .Include(b => b.BuildingDocumentRelations)
-                .FirstOrDefaultAsync(b => b.BuildingId == id).ConfigureAwait(false);
-
+            var building = await _context.Buildings.FirstOrDefaultAsync(b => b.BuildingId == id).ConfigureAwait(false);
             if (building == null)
                 return NotFound();
-
-            return building;
+            var orgName = _context.Organizations.Where(o => o.OrganizationId == building.OrganizationId).Select(o => o.Name).FirstOrDefault();
+            var documents = _context.Documents
+                .Where(d => d.BuildingId == id)
+                .Select(d => new KeyValuePair<int, string>(d.DocumentId, d.Title))
+                .ToList();
+            var dto = new BuildingDto
+            {
+                BuildingId = building.BuildingId,
+                Name = building.Name,
+                StreetName = building.StreetName,
+                HouseNumber = building.HouseNumber,
+                PostalCode = building.PostalCode,
+                City = building.City,
+                Country = building.Country,
+                ConstructionYear = building.ConstructionYear,
+                TotalArea = building.TotalArea,
+                Floors = building.Floors,
+                Description = building.Description,
+                Coordinates = building.Coordinates?.ToString(),
+                CreatedAt = building.CreatedAt,
+                UpdatedAt = building.UpdatedAt,
+                OrganizationId = building.OrganizationId,
+                OrganizationName = orgName,
+                Documents = documents
+            };
+            return Ok(dto);
         }
 
         // PUT: api/Buildings/{id}

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -91,7 +91,7 @@ namespace BUILD.ING.Controllers
                 OrganizationId = b.OrganizationId,
                 OrganizationName = orgMap.ContainsKey(b.OrganizationId) ? orgMap[b.OrganizationId] : null,
                 Documents = documents.Where(d => d.BuildingId == b.BuildingId)
-                    .Select(d => new KeyValuePair<int, string>(d.DocumentId, d.Title)).ToList()
+                    .Select(d => new DocumentIdTitleDto { Id = d.DocumentId, Title = d.Title }).ToList()
             }).ToList();
             return Ok(dtos);
         }
@@ -107,7 +107,7 @@ namespace BUILD.ING.Controllers
             var orgName = _context.Organizations.Where(o => o.OrganizationId == building.OrganizationId).Select(o => o.Name).FirstOrDefault();
             var documents = _context.Documents
                 .Where(d => d.BuildingId == id)
-                .Select(d => new KeyValuePair<int, string>(d.DocumentId, d.Title))
+                .Select(d => new DocumentIdTitleDto { Id = d.DocumentId, Title = d.Title })
                 .ToList();
             var dto = new BuildingDto
             {

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -121,14 +121,22 @@ namespace BUILD.ING.Controllers
             if (document == null)
                 return NotFound();
 
-            // Handle Category lookup
+            // Handle Category lookup or creation
             if (!string.IsNullOrEmpty(request.Category))
             {
                 var category = _context.DocumentCategories.FirstOrDefault(c => c.Name == request.Category);
                 if (category == null)
-                    return BadRequest($"Category '{request.Category}' not found.");
+                {
+                    category = new DocumentCategory { Name = request.Category };
+                    _context.DocumentCategories.Add(category);
+                    _context.SaveChanges(); // Save to get the generated CategoryId
+                }
                 document.CategoryId = category.CategoryId;
                 document.Category = category;
+                if (category.Documents == null)
+                    category.Documents = new List<Document>();
+                if (!category.Documents.Contains(document))
+                    category.Documents.Add(document);
             }
 
             // Handle Building lookup

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -121,10 +121,35 @@ namespace BUILD.ING.Controllers
             if (document == null)
                 return NotFound();
 
+            // Handle Category lookup
+            if (!string.IsNullOrEmpty(request.Category))
+            {
+                var category = _context.DocumentCategories.FirstOrDefault(c => c.Name == request.Category);
+                if (category == null)
+                    return BadRequest($"Category '{request.Category}' not found.");
+                document.CategoryId = category.CategoryId;
+                document.Category = category;
+            }
+
+            // Handle Building lookup
+            if (!string.IsNullOrEmpty(request.Building))
+            {
+                var building = _context.Buildings.FirstOrDefault(b => b.Name == request.Building);
+                if (building == null)
+                    return BadRequest($"Building '{request.Building}' not found.");
+                document.BuildingId = building.BuildingId;
+                document.Building = building;
+            }
+
             var requestType = request.GetType();
             var documentType = document.GetType();
             foreach (var reqProp in requestType.GetProperties())
             {
+                if (reqProp.Name == "Category" || reqProp.Name == "Building")
+                    continue; // Already handled above
+                var value = reqProp.GetValue(request);
+                if (value == null)
+                    continue; // Skip nulls to keep original value
                 var docProp = documentType.GetProperty(reqProp.Name);
                 if (docProp == null || !docProp.CanWrite)
                 {
@@ -134,7 +159,7 @@ namespace BUILD.ING.Controllers
                 {
                     return BadRequest($"Type mismatch for field '{reqProp.Name}': expected {docProp.PropertyType.Name}, got {reqProp.PropertyType.Name}.");
                 }
-                docProp.SetValue(document, reqProp.GetValue(request));
+                docProp.SetValue(document, value);
             }
 
             _context.SaveChanges();

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -111,7 +111,30 @@ namespace BUILD.ING.Controllers
             if (document == null)
                 return NotFound();
 
-            return Ok(document);
+            var dto = new BUILD.ING.Dto.DocumentDto
+            {
+                DocumentId = document.DocumentId,
+                Title = document.Title,
+                FilePath = document.FilePath,
+                FileType = document.FileType,
+                FileSize = document.FileSize,
+                CategoryId = document.CategoryId,
+                CategoryName = document.Category?.Name,
+                BuildingId = document.BuildingId,
+                BuildingName = document.Building?.Name,
+                UploadedBy = document.UploadedBy,
+                UploadDate = document.UploadDate,
+                LastModified = document.LastModified,
+                Version = document.Version,
+                Status = document.Status,
+                Description = document.Description,
+                IsPublic = document.IsPublic,
+                Metadata = document.Metadata,
+                FileName = document.FileName,
+                UploadedAt = document.UploadedAt,
+                GroupId = document.GroupId
+            };
+            return Ok(dto);
         }
 
         [HttpPut("{id}")]
@@ -167,7 +190,34 @@ namespace BUILD.ING.Controllers
             }
 
             _context.SaveChanges();
-            return Ok(document);
+            // Reload navigation properties to ensure up-to-date values
+            _context.Entry(document).Reference(d => d.Category).Load();
+            _context.Entry(document).Reference(d => d.Building).Load();
+
+            var dto = new BUILD.ING.Dto.DocumentDto
+            {
+                DocumentId = document.DocumentId,
+                Title = document.Title,
+                FilePath = document.FilePath,
+                FileType = document.FileType,
+                FileSize = document.FileSize,
+                CategoryId = document.CategoryId,
+                CategoryName = document.Category?.Name,
+                BuildingId = document.BuildingId,
+                BuildingName = document.Building?.Name,
+                UploadedBy = document.UploadedBy,
+                UploadDate = document.UploadDate,
+                LastModified = document.LastModified,
+                Version = document.Version,
+                Status = document.Status,
+                Description = document.Description,
+                IsPublic = document.IsPublic,
+                Metadata = document.Metadata,
+                FileName = document.FileName,
+                UploadedAt = document.UploadedAt,
+                GroupId = document.GroupId
+            };
+            return Ok(dto);
         }
 
         [HttpDelete("{id}")]

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -100,7 +100,30 @@ namespace BUILD.ING.Controllers
         {
             var groupId = GetCurrentUserGroupId();
             var documents = _context.Documents.Where(d => d.GroupId == groupId).ToList();
-            return Ok(documents);
+            var dtos = documents.Select(document => new BUILD.ING.Dto.DocumentDto
+            {
+                DocumentId = document.DocumentId,
+                Title = document.Title,
+                FilePath = document.FilePath,
+                FileType = document.FileType,
+                FileSize = document.FileSize,
+                CategoryId = document.CategoryId,
+                CategoryName = document.Category?.Name,
+                BuildingId = document.BuildingId,
+                BuildingName = document.Building?.Name,
+                UploadedBy = document.UploadedBy,
+                UploadDate = document.UploadDate,
+                LastModified = document.LastModified,
+                Version = document.Version,
+                Status = document.Status,
+                Description = document.Description,
+                IsPublic = document.IsPublic,
+                Metadata = document.Metadata,
+                FileName = document.FileName,
+                UploadedAt = document.UploadedAt,
+                GroupId = document.GroupId
+            }).ToList();
+            return Ok(dtos);
         }
 
         [HttpGet("{id}")]

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -121,9 +121,23 @@ namespace BUILD.ING.Controllers
             if (document == null)
                 return NotFound();
 
-            document.Title = request.Title;
-            _context.SaveChanges();
+            var requestType = request.GetType();
+            var documentType = document.GetType();
+            foreach (var reqProp in requestType.GetProperties())
+            {
+                var docProp = documentType.GetProperty(reqProp.Name);
+                if (docProp == null || !docProp.CanWrite)
+                {
+                    return BadRequest($"Field '{reqProp.Name}' does not exist on Document.");
+                }
+                if (!docProp.PropertyType.IsAssignableFrom(reqProp.PropertyType))
+                {
+                    return BadRequest($"Type mismatch for field '{reqProp.Name}': expected {docProp.PropertyType.Name}, got {reqProp.PropertyType.Name}.");
+                }
+                docProp.SetValue(document, reqProp.GetValue(request));
+            }
 
+            _context.SaveChanges();
             return Ok(document);
         }
 

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -133,10 +133,6 @@ namespace BUILD.ING.Controllers
                 }
                 document.CategoryId = category.CategoryId;
                 document.Category = category;
-                if (category.Documents == null)
-                    category.Documents = new List<Document>();
-                if (!category.Documents.Contains(document))
-                    category.Documents.Add(document);
             }
 
             // Handle Building lookup

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -186,6 +186,10 @@ namespace BUILD.ING.Controllers
                 }
                 document.CategoryId = category.CategoryId;
                 document.Category = category;
+                if (category.Documents == null)
+                    category.Documents = new List<Document>();
+                if (!category.Documents.Contains(document))
+                    category.Documents.Add(document); // Ensure the document is linked to the category
             }
 
             // Handle Building lookup
@@ -196,6 +200,10 @@ namespace BUILD.ING.Controllers
                     return BadRequest($"Building '{request.Building}' not found.");
                 document.BuildingId = building.BuildingId;
                 document.Building = building;
+                if (building.Documents == null)
+                    building.Documents = new List<Document>();
+                if (!building.Documents.Contains(document))
+                    building.Documents.Add(document); // Ensure the document is linked to the building
             }
 
             var requestType = request.GetType();

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -100,6 +100,8 @@ namespace BUILD.ING.Controllers
         {
             var groupId = GetCurrentUserGroupId();
             var documents = _context.Documents.Where(d => d.GroupId == groupId).ToList();
+            var categoryMap = _context.DocumentCategories.ToDictionary(c => c.CategoryId, c => c.Name);
+            var buildingMap = _context.Buildings.ToDictionary(b => b.BuildingId, b => b.Name);
             var dtos = documents.Select(document => new BUILD.ING.Dto.DocumentDto
             {
                 DocumentId = document.DocumentId,
@@ -108,9 +110,9 @@ namespace BUILD.ING.Controllers
                 FileType = document.FileType,
                 FileSize = document.FileSize,
                 CategoryId = document.CategoryId,
-                CategoryName = document.Category?.Name,
+                CategoryName = document.CategoryId.HasValue && categoryMap.ContainsKey(document.CategoryId.Value) ? categoryMap[document.CategoryId.Value] : null,
                 BuildingId = document.BuildingId,
-                BuildingName = document.Building?.Name,
+                BuildingName = document.BuildingId.HasValue && buildingMap.ContainsKey(document.BuildingId.Value) ? buildingMap[document.BuildingId.Value] : null,
                 UploadedBy = document.UploadedBy,
                 UploadDate = document.UploadDate,
                 LastModified = document.LastModified,
@@ -133,7 +135,12 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == groupId);
             if (document == null)
                 return NotFound();
-
+            var categoryName = document.CategoryId.HasValue
+                ? _context.DocumentCategories.Where(c => c.CategoryId == document.CategoryId.Value).Select(c => c.Name).FirstOrDefault()
+                : null;
+            var buildingName = document.BuildingId.HasValue
+                ? _context.Buildings.Where(b => b.BuildingId == document.BuildingId.Value).Select(b => b.Name).FirstOrDefault()
+                : null;
             var dto = new BUILD.ING.Dto.DocumentDto
             {
                 DocumentId = document.DocumentId,
@@ -142,9 +149,9 @@ namespace BUILD.ING.Controllers
                 FileType = document.FileType,
                 FileSize = document.FileSize,
                 CategoryId = document.CategoryId,
-                CategoryName = document.Category?.Name,
+                CategoryName = categoryName,
                 BuildingId = document.BuildingId,
-                BuildingName = document.Building?.Name,
+                BuildingName = buildingName,
                 UploadedBy = document.UploadedBy,
                 UploadDate = document.UploadDate,
                 LastModified = document.LastModified,
@@ -161,7 +168,7 @@ namespace BUILD.ING.Controllers
         }
 
         [HttpPut("{id}")]
-        public IActionResult UpdateDocumentTitle(int id, [FromBody] DocumentUpdateRequest request)
+        public IActionResult UpdateDocument(int id, [FromBody] DocumentUpdateRequest request)
         {
             var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == GetCurrentUserGroupId());
             if (document == null)

--- a/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace BUILD.ING.Dto
+{
+    public class BuildingDto
+    {
+        public int BuildingId { get; set; }
+        public string Name { get; set; }
+        public string StreetName { get; set; }
+        public string HouseNumber { get; set; }
+        public string PostalCode { get; set; }
+        public string City { get; set; }
+        public string? Country { get; set; }
+        public int? ConstructionYear { get; set; }
+        public decimal? TotalArea { get; set; }
+        public int? Floors { get; set; }
+        public string Description { get; set; }
+        public string? Coordinates { get; set; } // You may want to format NpgsqlPoint as string or object
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public int OrganizationId { get; set; }
+        public string? OrganizationName { get; set; }
+        public List<KeyValuePair<int, string>> Documents { get; set; } = new List<KeyValuePair<int, string>>();
+    }
+}

--- a/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 
 namespace BUILD.ING.Dto
 {
+    public class DocumentIdTitleDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+    }
+
     public class BuildingDto
     {
         public int BuildingId { get; set; }
@@ -21,6 +27,6 @@ namespace BUILD.ING.Dto
         public DateTime UpdatedAt { get; set; }
         public int OrganizationId { get; set; }
         public string? OrganizationName { get; set; }
-        public List<KeyValuePair<int, string>> Documents { get; set; } = new List<KeyValuePair<int, string>>();
+        public List<DocumentIdTitleDto> Documents { get; set; } = new List<DocumentIdTitleDto>();
     }
 }

--- a/BitAndBeam/backend/BUILD.ING/Dto/DocumentDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/DocumentDto.cs
@@ -1,0 +1,26 @@
+namespace BUILD.ING.Dto
+{
+    public class DocumentDto
+    {
+        public int DocumentId { get; set; }
+        public string Title { get; set; }
+        public string FilePath { get; set; }
+        public string FileType { get; set; }
+        public int FileSize { get; set; }
+        public int? CategoryId { get; set; }
+        public string? CategoryName { get; set; }
+        public int? BuildingId { get; set; }
+        public string? BuildingName { get; set; }
+        public int? UploadedBy { get; set; }
+        public DateTime UploadDate { get; set; }
+        public DateTime LastModified { get; set; }
+        public string Version { get; set; }
+        public string Status { get; set; }
+        public string Description { get; set; }
+        public bool IsPublic { get; set; }
+        public string Metadata { get; set; }
+        public string FileName { get; set; }
+        public DateTime UploadedAt { get; set; }
+        public string GroupId { get; set; }
+    }
+}

--- a/BitAndBeam/backend/BUILD.ING/Migrations/20250525142835_InitialCreate.Designer.cs
+++ b/BitAndBeam/backend/BUILD.ING/Migrations/20250525142835_InitialCreate.Designer.cs
@@ -184,7 +184,6 @@ namespace Build.ING.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("Name")

--- a/BitAndBeam/backend/BUILD.ING/Migrations/20250525142835_InitialCreate.cs
+++ b/BitAndBeam/backend/BUILD.ING/Migrations/20250525142835_InitialCreate.cs
@@ -20,7 +20,7 @@ namespace Build.ING.Migrations
                     CategoryId = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     Name = table.Column<string>(type: "text", nullable: false),
-                    Description = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
                     ParentCategoryId = table.Column<int>(type: "integer", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },

--- a/BitAndBeam/backend/BUILD.ING/Migrations/AppDbContextModelSnapshot.cs
+++ b/BitAndBeam/backend/BUILD.ING/Migrations/AppDbContextModelSnapshot.cs
@@ -196,7 +196,6 @@ namespace Build.ING.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("Name")

--- a/BitAndBeam/backend/BUILD.ING/Models/Building.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/Building.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using NpgsqlTypes;
 
 namespace BUILD.ING.Models
@@ -24,6 +25,7 @@ namespace BUILD.ING.Models
         public int OrganizationId { get; set; }
         public Organization Organization { get; set; }
 
+        [JsonIgnore]
         public ICollection<Document> Documents { get; set; }
         public ICollection<BuildingDocumentRelation> BuildingDocumentRelations { get; set; }
     }

--- a/BitAndBeam/backend/BUILD.ING/Models/Building.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/Building.cs
@@ -25,7 +25,6 @@ namespace BUILD.ING.Models
         public int OrganizationId { get; set; }
         public Organization Organization { get; set; }
 
-        [JsonIgnore]
         public ICollection<Document> Documents { get; set; }
         public ICollection<BuildingDocumentRelation> BuildingDocumentRelations { get; set; }
     }

--- a/BitAndBeam/backend/BUILD.ING/Models/DocumentCategory.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/DocumentCategory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace BUILD.ING.Models
 {
@@ -13,6 +14,7 @@ namespace BUILD.ING.Models
 
         public DocumentCategory ParentCategory { get; set; }
         public ICollection<DocumentCategory> SubCategories { get; set; }
+        [JsonIgnore]
         public ICollection<Document> Documents { get; set; }
     }
 }

--- a/BitAndBeam/backend/BUILD.ING/Models/DocumentCategory.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/DocumentCategory.cs
@@ -7,7 +7,7 @@ namespace BUILD.ING.Models
     {
         public int CategoryId { get; set; }
         public string Name { get; set; }
-        public string Description { get; set; }
+        public string? Description { get; set; }
         public int? ParentCategoryId { get; set; }
         public DateTime CreatedAt { get; set; }
 

--- a/BitAndBeam/backend/BUILD.ING/Models/DocumentCategory.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/DocumentCategory.cs
@@ -14,7 +14,6 @@ namespace BUILD.ING.Models
 
         public DocumentCategory ParentCategory { get; set; }
         public ICollection<DocumentCategory> SubCategories { get; set; }
-        [JsonIgnore]
         public ICollection<Document> Documents { get; set; }
     }
 }

--- a/BitAndBeam/backend/BUILD.ING/Models/DocumentUpdateRequest.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/DocumentUpdateRequest.cs
@@ -9,6 +9,7 @@ namespace BUILD.ING.Models
         /// New title, category and/or building of the document. If a property is null, the original value is kept.
         /// </summary>
         public string? Title { get; set; }
+        public string? Description { get; set; }
         public string? Category { get; set; }
         public string? Building { get; set; }
     }

--- a/BitAndBeam/backend/BUILD.ING/Models/DocumentUpdateRequest.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/DocumentUpdateRequest.cs
@@ -6,8 +6,10 @@ namespace BUILD.ING.Models
     public class DocumentUpdateRequest
     {
         /// <summary>
-        /// New title of the document
+        /// New title, category and/or building of the document. If a property is null, the original value is kept.
         /// </summary>
-        public string Title { get; set; } = string.Empty;
+        public string? Title { get; set; }
+        public string? Category { get; set; }
+        public string? Building { get; set; }
     }
 }

--- a/BitAndBeam/database/database_diagram.dbml
+++ b/BitAndBeam/database/database_diagram.dbml
@@ -37,7 +37,7 @@ Table buildings {
 Table document_categories {
   category_id serial [pk]
   name varchar(50) [not null]
-  description text
+  description text [default: null]
   parent_category_id integer [ref: > document_categories.category_id]
   created_at timestamp [default: `CURRENT_TIMESTAMP`]
 }

--- a/BitAndBeam/database/schema.sql
+++ b/BitAndBeam/database/schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE "buildings" (
 CREATE TABLE "document_categories" (
     "category_id" SERIAL PRIMARY KEY,
     "name" VARCHAR(50) NOT NULL,
-    "description" TEXT,
+    "description" TEXT DEFAULT NULL,
     "parent_category_id" INTEGER REFERENCES "document_categories" ("category_id") ON DELETE SET NULL,
     "created_at" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/BitAndBeam/frontend/src/api/api.ts
+++ b/BitAndBeam/frontend/src/api/api.ts
@@ -453,12 +453,6 @@ export interface DocumentCategory {
      * @memberof DocumentCategory
      */
     'subCategories'?: Array<DocumentCategory> | null;
-    /**
-     * 
-     * @type {Array<Document>}
-     * @memberof DocumentCategory
-     */
-    'documents'?: Array<Document> | null;
 }
 /**
  * 

--- a/BitAndBeam/frontend/src/api/api.ts
+++ b/BitAndBeam/frontend/src/api/api.ts
@@ -127,12 +127,6 @@ export interface Building {
     'organization'?: Organization;
     /**
      * 
-     * @type {Array<Document>}
-     * @memberof Building
-     */
-    'documents'?: Array<Document> | null;
-    /**
-     * 
      * @type {Array<BuildingDocumentRelation>}
      * @memberof Building
      */

--- a/BitAndBeam/frontend/src/api/api.ts
+++ b/BitAndBeam/frontend/src/api/api.ts
@@ -584,11 +584,29 @@ export interface DocumentTagRelation {
  */
 export interface DocumentUpdateRequest {
     /**
-     * New title of the document
+     * New title, category and/or building of the document. If a property is null, the original value is kept.
      * @type {string}
      * @memberof DocumentUpdateRequest
      */
     'title'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentUpdateRequest
+     */
+    'description'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentUpdateRequest
+     */
+    'category'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentUpdateRequest
+     */
+    'building'?: string | null;
 }
 /**
  * 

--- a/BitAndBeam/frontend/src/api/api.ts
+++ b/BitAndBeam/frontend/src/api/api.ts
@@ -127,6 +127,12 @@ export interface Building {
     'organization'?: Organization;
     /**
      * 
+     * @type {Array<Document>}
+     * @memberof Building
+     */
+    'documents'?: Array<Document> | null;
+    /**
+     * 
      * @type {Array<BuildingDocumentRelation>}
      * @memberof Building
      */
@@ -247,6 +253,115 @@ export interface BuildingDocumentRelation {
      * @memberof BuildingDocumentRelation
      */
     'relationType'?: string | null;
+}
+/**
+ * 
+ * @export
+ * @interface BuildingDto
+ */
+export interface BuildingDto {
+    /**
+     * 
+     * @type {number}
+     * @memberof BuildingDto
+     */
+    'buildingId'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'name'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'streetName'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'houseNumber'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'postalCode'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'city'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'country'?: string | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof BuildingDto
+     */
+    'constructionYear'?: number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof BuildingDto
+     */
+    'totalArea'?: number | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof BuildingDto
+     */
+    'floors'?: number | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'description'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'coordinates'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'createdAt'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'updatedAt'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof BuildingDto
+     */
+    'organizationId'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof BuildingDto
+     */
+    'organizationName'?: string | null;
+    /**
+     * 
+     * @type {Array<DocumentIdTitleDto>}
+     * @memberof BuildingDto
+     */
+    'documents'?: Array<DocumentIdTitleDto> | null;
 }
 /**
  * 
@@ -447,6 +562,31 @@ export interface DocumentCategory {
      * @memberof DocumentCategory
      */
     'subCategories'?: Array<DocumentCategory> | null;
+    /**
+     * 
+     * @type {Array<Document>}
+     * @memberof DocumentCategory
+     */
+    'documents'?: Array<Document> | null;
+}
+/**
+ * 
+ * @export
+ * @interface DocumentIdTitleDto
+ */
+export interface DocumentIdTitleDto {
+    /**
+     * 
+     * @type {number}
+     * @memberof DocumentIdTitleDto
+     */
+    'id'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof DocumentIdTitleDto
+     */
+    'title'?: string | null;
 }
 /**
  * 
@@ -1266,7 +1406,7 @@ export const BuildingsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiBuildingsGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Building>>> {
+        async apiBuildingsGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<BuildingDto>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiBuildingsGet(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['BuildingsApi.apiBuildingsGet']?.[localVarOperationServerIndex]?.url;
@@ -1290,7 +1430,7 @@ export const BuildingsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiBuildingsIdGet(id: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Building>> {
+        async apiBuildingsIdGet(id: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<BuildingDto>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiBuildingsIdGet(id, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['BuildingsApi.apiBuildingsIdGet']?.[localVarOperationServerIndex]?.url;
@@ -1352,7 +1492,7 @@ export const BuildingsApiFactory = function (configuration?: Configuration, base
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiBuildingsGet(options?: any): AxiosPromise<Array<Building>> {
+        apiBuildingsGet(options?: any): AxiosPromise<Array<BuildingDto>> {
             return localVarFp.apiBuildingsGet(options).then((request) => request(axios, basePath));
         },
         /**
@@ -1370,7 +1510,7 @@ export const BuildingsApiFactory = function (configuration?: Configuration, base
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiBuildingsIdGet(id: number, options?: any): AxiosPromise<Building> {
+        apiBuildingsIdGet(id: number, options?: any): AxiosPromise<BuildingDto> {
             return localVarFp.apiBuildingsIdGet(id, options).then((request) => request(axios, basePath));
         },
         /**


### PR DESCRIPTION
updated Document PUT endpoint to allow editing title, description, categoryID and buildingID

create category if not present, reject request if building not present

Using Dto to respond to Get requests instead of plain serialization to avoid looping document to category or document to building relation

