### PR TITLE
Fix/auto detect building from uploaded document content

### DIFF
--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -170,10 +170,12 @@ namespace BUILD.ING.Controllers
                 Status = "draft",
                 IsPublic = false,
                 Description = "No description provided",
-                Metadata = metadata, // Store the extracted metadata
+                Metadata = metadata,
                 UploadedAt = DateTime.UtcNow,
                 UploadedBy = null,
-                GroupId = GetCurrentUserGroupId()
+                GroupId = GetCurrentUserGroupId(),
+                BuildingId = matchedBuilding?.BuildingId,
+                Building = matchedBuilding
             };
 
             _context.Documents.Add(document);
@@ -196,18 +198,11 @@ namespace BUILD.ING.Controllers
                         { "zip_code", "Couldn't identify" },
                         { "city", "Couldn't identify" }
                     },
-                DetectedBuilding = matchedBuilding != null
-                    ? new
-                    {
-                        matchedBuilding.BuildingId,
-                        matchedBuilding.StreetName,
-                        matchedBuilding.HouseNumber,
-                        matchedBuilding.PostalCode,
-                        matchedBuilding.City
-                    }
-                    : null
+                BuildingId = matchedBuilding?.BuildingId,
+                BuildingName = matchedBuilding?.Name
             });
         }
+
 
         [HttpGet]
         public IActionResult GetAllDocuments()

--- a/BitAndBeam/backend/BUILD.ING/Services/TikaService.cs
+++ b/BitAndBeam/backend/BUILD.ING/Services/TikaService.cs
@@ -10,9 +10,6 @@ namespace BUILD.ING.Services
 {
     public class TikaService
     {
-        private const int DefaultOcrTimeoutMillis = 20000; // 20s
-        private const int DefaultMaxExtractLength = 1000000; // 1 MB of text
-
         private readonly HttpClient _client;
         private readonly ILogger<TikaService> _logger;
 


### PR DESCRIPTION
This PR introduces the backend logic to automatically detect and associate a building based on the content of an uploaded document.

✅ Key Changes:
- Used Ollama service to extract building address details (street, zip code, house number, city) from document content.
- Matched the extracted address against existing buildings in the database using case-insensitive comparison.
- Automatically assigned BuildingId and BuildingName to the uploaded document if a match is found.
- Updated the API response to include BuildingId, BuildingName, and SuggestedAddress.
- Removed unused DetectedBuilding field from the response.