### PR TITLE
Fix organization

### DIFF
--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -164,10 +164,11 @@ namespace BUILD.ING.Controllers
                 return BadRequest("Mismatched Building ID");
 
             //var existingBuilding = await _context.Buildings.FindAsync(id).ConfigureAwait(false);
+            var orgId = GetCurrentUserOrganizationId();
             var existingBuilding = await _context.Buildings
-                //.Include(b => b.Documents)
                 .Include(b => b.BuildingDocumentRelations)
-                .FirstOrDefaultAsync(b => b.BuildingId == id).ConfigureAwait(false);
+                .FirstOrDefaultAsync(b => b.BuildingId == id && b.OrganizationId == orgId).ConfigureAwait(false);
+
 
 
             if (existingBuilding == null)
@@ -246,9 +247,11 @@ namespace BUILD.ING.Controllers
         {
             _logger.LogInformation("DeleteBuilding called for ID {BuildingId} at {Time}", id, DateTime.UtcNow);
 
+            var orgId = GetCurrentUserOrganizationId();
             var building = await _context.Buildings
                 .Include(b => b.BuildingDocumentRelations)
-                .FirstOrDefaultAsync(b => b.BuildingId == id).ConfigureAwait(false);
+                .FirstOrDefaultAsync(b => b.BuildingId == id && b.OrganizationId == orgId).ConfigureAwait(false);
+
 
             if (building == null)
             {

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -276,11 +276,13 @@ namespace BUILD.ING.Controllers
 
             return NoContent();
         }
+
+        private int GetCurrentUserOrganizationId()
+            {
+                return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+            }
     }
 
-    private int GetCurrentUserOrganizationId()
-    {
-        return int.Parse(User.Claims.First(c => c.Type == "org").Value);
-    }
+
 
 }

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -25,6 +25,11 @@ namespace BUILD.ING.Controllers
             _logger = logger;
         }
 
+        private int GetCurrentUserOrganizationId()
+        {
+             return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+        }
+
         // POST: api/Buildings
         // Creates a new building and returns its ID
         [HttpPost]
@@ -276,11 +281,6 @@ namespace BUILD.ING.Controllers
 
             return NoContent();
         }
-
-        private int GetCurrentUserOrganizationId()
-            {
-                return int.Parse(User.Claims.First(c => c.Type == "org").Value);
-            }
     }
 
 

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -174,11 +174,12 @@ namespace BUILD.ING.Controllers
             if (existingBuilding == null)
                 return NotFound();
 
-            // If the incoming organizationId is null or 0, preserve existing one
-            if (updatedBuilding.OrganizationId == 0)
-                updatedBuilding.OrganizationId = existingBuilding.OrganizationId;
+            // Ignore what the client sent, and instead always set the org based on the logged-in user
+            //if (updatedBuilding.OrganizationId == 0)
+                existingBuilding.OrganizationId = orgId;
 
-            _context.Entry(existingBuilding).CurrentValues.SetValues(updatedBuilding);
+            //Could accidentally overwrite something you're protecting (e.g., OrganizationId, relations)
+            //_context.Entry(existingBuilding).CurrentValues.SetValues(updatedBuilding);
 
 
             // Update only editable fields

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -272,4 +272,10 @@ namespace BUILD.ING.Controllers
             return NoContent();
         }
     }
+
+    private int GetCurrentUserOrganizationId()
+    {
+        return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+    }
+
 }

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -79,7 +79,8 @@ namespace BUILD.ING.Controllers
         {
             _logger.LogInformation("GetBuildings called at {Time}", DateTime.UtcNow);
 
-            var buildings = await _context.Buildings.ToListAsync().ConfigureAwait(false);
+            int orgId = GetCurrentUserOrganizationId();
+            var buildings = await _context.Buildings.Where(b => b.OrganizationId == orgId).ToListAsync().ConfigureAwait(false);
             var buildingIds = buildings.Select(b => b.BuildingId).ToList();
             var documents = _context.Documents
                 .Where(d => d.BuildingId.HasValue && buildingIds.Contains(d.BuildingId.Value))
@@ -117,8 +118,8 @@ namespace BUILD.ING.Controllers
         public async Task<ActionResult<BuildingDto>> GetBuilding(int id)
         {
             _logger.LogInformation("GetBuilding called for ID {BuildingId} at {Time}", id, DateTime.UtcNow);
-
-            var building = await _context.Buildings.FirstOrDefaultAsync(b => b.BuildingId == id).ConfigureAwait(false);
+            var orgId = GetCurrentUserOrganizationId();
+            var building = await _context.Buildings.FirstOrDefaultAsync(b => b.BuildingId == id && b.OrganizationId == orgId).ConfigureAwait(false);
             if (building == null)
             {
                 _logger.LogWarning("GetBuilding did not find building with ID {BuildingId}", id);

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -27,7 +27,7 @@ namespace BUILD.ING.Controllers
 
         private int GetCurrentUserOrganizationId()
         {
-             return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+            return int.Parse(User.Claims.First(c => c.Type == "org").Value);
         }
 
         // POST: api/Buildings
@@ -181,7 +181,7 @@ namespace BUILD.ING.Controllers
 
             // Ignore what the client sent, and instead always set the org based on the logged-in user
             //if (updatedBuilding.OrganizationId == 0)
-                existingBuilding.OrganizationId = orgId;
+            existingBuilding.OrganizationId = orgId;
 
             //Could accidentally overwrite something you're protecting (e.g., OrganizationId, relations)
             //_context.Entry(existingBuilding).CurrentValues.SetValues(updatedBuilding);

--- a/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/BuildingsController.cs
@@ -49,7 +49,7 @@ namespace BUILD.ING.Controllers
                 TotalArea = dto.TotalArea,
                 Floors = dto.Floors,
                 Description = dto.Description,
-                OrganizationId = dto.OrganizationId,
+                OrganizationId = GetCurrentUserOrganizationId(),
                 Coordinates = coordinates,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow,

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -213,8 +213,15 @@ namespace BUILD.ING.Controllers
         [HttpGet]
         public IActionResult GetAllDocuments()
         {
-            var groupId = GetCurrentUserGroupId();
-            var documents = _context.Documents.Where(d => d.GroupId == groupId).ToList();
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var documents = _context.Documents
+                .Where(d => !d.BuildingId.HasValue || buildingIds.Contains(d.BuildingId.Value))
+                .ToList();
             var dtos = documents.Select(document => new BUILD.ING.Dto.DocumentDto
             {
                 DocumentId = document.DocumentId,

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -31,11 +31,7 @@ namespace BUILD.ING.Controllers
             _logger = logger;
         }
 
-        private string GetCurrentUserGroupId()
-        {
-            return "group2"; // Hardcoded for now
-        }
-
+     
         private static string CategoriesJsonPath => Path.Combine("/app/resources", "document_categories.json");
 
         private static List<DocumentCategory> ReadCategories()

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -344,7 +344,17 @@ namespace BUILD.ING.Controllers
         public IActionResult UpdateDocument(int id, [FromBody] DocumentUpdateRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
-            var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == GetCurrentUserGroupId());
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var document = _context.Documents
+                .FirstOrDefault(d =>
+                    d.DocumentId == id &&
+                    (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
             if (document == null)
                 return NotFound();
 

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -136,7 +136,10 @@ namespace BUILD.ING.Controllers
                         parsedAddress.TryGetValue("house_number", out var houseNumber);
                         parsedAddress.TryGetValue("city", out var city);
 
-                        var buildings = _context.Buildings.ToList();
+                        var orgId = GetCurrentUserOrganizationId();
+                        var buildings = _context.Buildings
+                            .Where(b => b.OrganizationId == orgId)
+                            .ToList();
                         foreach (var building in buildings)
                         {
                             bool matchesStreet = string.Equals(building.StreetName?.Trim(), street?.Trim(), StringComparison.OrdinalIgnoreCase);

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -364,7 +364,9 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents
                 .FirstOrDefault(d =>
                     d.DocumentId == id &&
+                    d.OrganizationId == orgId &&
                     (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
 
             if (document == null)
                 return NotFound();
@@ -425,7 +427,9 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents
                 .FirstOrDefault(d =>
                     d.DocumentId == id &&
+                    d.OrganizationId == orgId &&
                     (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
 
             if (document == null)
                 return NotFound();
@@ -492,8 +496,8 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents
                 .FirstOrDefault(d =>
                     d.DocumentId == id &&
+                    d.OrganizationId == orgId &&
                     (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
-
             if (document == null)
                 return NotFound();
 
@@ -526,7 +530,9 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents
                 .FirstOrDefault(d =>
                     d.DocumentId == id &&
+                    d.OrganizationId == orgId &&
                     (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
 
             if (document == null)
                 return NotFound();
@@ -551,6 +557,7 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents
                 .FirstOrDefault(d =>
                     d.DocumentId == id &&
+                    d.OrganizationId == orgId &&
                     (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
             if (document == null)
                 return NotFound();

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -405,7 +405,17 @@ namespace BUILD.ING.Controllers
         public IActionResult UpdateDocumentMetadata(int id, [FromBody] DocumentMetadataPatchRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
-            var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == GetCurrentUserGroupId());
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var document = _context.Documents
+                .FirstOrDefault(d =>
+                    d.DocumentId == id &&
+                    (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
             if (document == null)
                 return NotFound();
 
@@ -462,7 +472,17 @@ namespace BUILD.ING.Controllers
         [HttpDelete("{id}")]
         public IActionResult DeleteDocument(int id)
         {
-            var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == GetCurrentUserGroupId());
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var document = _context.Documents
+                .FirstOrDefault(d =>
+                    d.DocumentId == id &&
+                    (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
             if (document == null)
                 return NotFound();
 
@@ -487,7 +507,17 @@ namespace BUILD.ING.Controllers
         public IActionResult DownloadDocument(int id)
         {
             var groupId = GetCurrentUserGroupId();
-            var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == groupId);
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var document = _context.Documents
+                .FirstOrDefault(d =>
+                    d.DocumentId == id &&
+                    (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
+
             if (document == null)
                 return NotFound();
 
@@ -503,7 +533,16 @@ namespace BUILD.ING.Controllers
         public IActionResult PreviewDocument(int id)
         {
             var groupId = GetCurrentUserGroupId();
-            var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == groupId);
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var document = _context.Documents
+                .FirstOrDefault(d =>
+                    d.DocumentId == id &&
+                    (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
             if (document == null)
                 return NotFound();
 

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -35,9 +35,9 @@ namespace BUILD.ING.Controllers
         private static string CategoriesJsonPath => Path.Combine("/app/resources", "document_categories.json");
 
         private int GetCurrentUserOrganizationId()
-          {
-             return int.Parse(User.Claims.First(c => c.Type == "org").Value);
-          }
+        {
+            return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+        }
 
         private static List<DocumentCategory> ReadCategories()
         {

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -34,6 +34,11 @@ namespace BUILD.ING.Controllers
 
         private static string CategoriesJsonPath => Path.Combine("/app/resources", "document_categories.json");
 
+        private int GetCurrentUserOrganizationId()
+          {
+             return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+          }
+
         private static List<DocumentCategory> ReadCategories()
         {
             var json = System.IO.File.ReadAllText(CategoriesJsonPath);
@@ -183,7 +188,7 @@ namespace BUILD.ING.Controllers
                 Metadata = metadata,
                 UploadedAt = DateTime.UtcNow,
                 UploadedBy = null,
-                GroupId = GetCurrentUserGroupId(),
+                OrganizationId = GetCurrentUserOrganizationId(),
                 BuildingId = matchedBuilding?.BuildingId,
             };
 
@@ -244,7 +249,7 @@ namespace BUILD.ING.Controllers
                 Metadata = document.Metadata,
                 FileName = document.FileName,
                 UploadedAt = document.UploadedAt,
-                GroupId = document.GroupId
+                OrganizationId = document.OrganizationId
             }).ToList();
             return Ok(dtos);
         }
@@ -283,7 +288,7 @@ namespace BUILD.ING.Controllers
                 Metadata = document.Metadata,
                 FileName = document.FileName,
                 UploadedAt = document.UploadedAt,
-                GroupId = document.GroupId
+                OrganizationId = document.OrganizationId
             };
             return Ok(dto);
         }
@@ -399,7 +404,7 @@ namespace BUILD.ING.Controllers
                 Metadata = document.Metadata,
                 FileName = document.FileName,
                 UploadedAt = document.UploadedAt,
-                GroupId = document.GroupId
+                OrganizationId = document.OrganizationId
             };
             return Ok(dto);
         }
@@ -467,7 +472,7 @@ namespace BUILD.ING.Controllers
                 Metadata = document.Metadata,
                 FileName = document.FileName,
                 UploadedAt = document.UploadedAt,
-                GroupId = document.GroupId
+                OrganizationId = document.OrganizationId
             };
             return Ok(dto);
         }
@@ -509,7 +514,6 @@ namespace BUILD.ING.Controllers
         [HttpGet("{id}/download")]
         public IActionResult DownloadDocument(int id)
         {
-            var groupId = GetCurrentUserGroupId();
             var orgId = GetCurrentUserOrganizationId();
             var buildingIds = _context.Buildings
                 .Where(b => b.OrganizationId == orgId)
@@ -535,7 +539,6 @@ namespace BUILD.ING.Controllers
         [HttpGet("{id}/preview")]
         public IActionResult PreviewDocument(int id)
         {
-            var groupId = GetCurrentUserGroupId();
             var orgId = GetCurrentUserOrganizationId();
             var buildingIds = _context.Buildings
                 .Where(b => b.OrganizationId == orgId)
@@ -582,10 +585,7 @@ namespace BUILD.ING.Controllers
             public string? Description { get; set; }
         }
 
-        private int GetCurrentUserOrganizationId()
-            {
-                return int.Parse(User.Claims.First(c => c.Type == "org").Value);
-            }
+
 
         // public class DocumentCategoryCreateRequest
         // {

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -582,6 +582,11 @@ namespace BUILD.ING.Controllers
             public string? Description { get; set; }
         }
 
+        private int GetCurrentUserOrganizationId()
+            {
+                return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+            }
+
         // public class DocumentCategoryCreateRequest
         // {
         //     public string Name { get; set; } = string.Empty;
@@ -590,10 +595,7 @@ namespace BUILD.ING.Controllers
         // }
     }
 
-    private int GetCurrentUserOrganizationId()
-    {
-        return int.Parse(User.Claims.First(c => c.Type == "org").Value);
-    }
+
 
 
 }

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -228,8 +228,10 @@ namespace BUILD.ING.Controllers
                 .ToList();
 
             var documents = _context.Documents
-                .Where(d => !d.BuildingId.HasValue || buildingIds.Contains(d.BuildingId.Value))
+                .Where(d => d.OrganizationId == orgId &&
+                            (!d.BuildingId.HasValue || buildingIds.Contains(d.BuildingId.Value)))
                 .ToList();
+
             var dtos = documents.Select(document => new BUILD.ING.Dto.DocumentDto
             {
                 DocumentId = document.DocumentId,
@@ -266,6 +268,7 @@ namespace BUILD.ING.Controllers
             var document = _context.Documents
                 .FirstOrDefault(d =>
                     d.DocumentId == id &&
+                    d.OrganizationId == orgId &&
                     (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
             if (document == null)
                 return NotFound();

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -31,7 +31,7 @@ namespace BUILD.ING.Controllers
             _logger = logger;
         }
 
-     
+
         private static string CategoriesJsonPath => Path.Combine("/app/resources", "document_categories.json");
 
         private static List<DocumentCategory> ReadCategories()
@@ -249,8 +249,16 @@ namespace BUILD.ING.Controllers
         [HttpGet("{id}")]
         public IActionResult GetDocumentById(int id)
         {
-            var groupId = GetCurrentUserGroupId();
-            var document = _context.Documents.FirstOrDefault(d => d.DocumentId == id && d.GroupId == groupId);
+            var orgId = GetCurrentUserOrganizationId();
+            var buildingIds = _context.Buildings
+                .Where(b => b.OrganizationId == orgId)
+                .Select(b => b.BuildingId)
+                .ToList();
+
+            var document = _context.Documents
+                .FirstOrDefault(d =>
+                    d.DocumentId == id &&
+                    (d.BuildingId == null || buildingIds.Contains(d.BuildingId.Value)));
             if (document == null)
                 return NotFound();
             var dto = new BUILD.ING.Dto.DocumentDto

--- a/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
+++ b/BitAndBeam/backend/BUILD.ING/Controllers/DocumentsController.cs
@@ -527,5 +527,11 @@ namespace BUILD.ING.Controllers
         // }
     }
 
+    private int GetCurrentUserOrganizationId()
+    {
+        return int.Parse(User.Claims.First(c => c.Type == "org").Value);
+    }
+
+
 }
 

--- a/BitAndBeam/backend/BUILD.ING/Dto/BuildingCreateDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/BuildingCreateDto.cs
@@ -13,7 +13,6 @@ namespace BUILD.ING.Dto
         public decimal? TotalArea { get; set; }
         public int? Floors { get; set; }
         public string Description { get; set; }
-        public int OrganizationId { get; set; }
         public NpgsqlPoint? Coordinates { get; set; }
     }
 }

--- a/BitAndBeam/backend/BUILD.ING/Dto/BuildingCreateDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/BuildingCreateDto.cs
@@ -13,6 +13,7 @@ namespace BUILD.ING.Dto
         public decimal? TotalArea { get; set; }
         public int? Floors { get; set; }
         public string Description { get; set; }
+        public int OrganizationId { get; set; }
         public NpgsqlPoint? Coordinates { get; set; }
     }
 }

--- a/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
@@ -16,7 +16,7 @@ namespace BUILD.ING.Dto
         public decimal? TotalArea { get; set; }
         public int? Floors { get; set; }
         public string Description { get; set; }
-        public string? Coordinates { get; set; } // You may want to format NpgsqlPoint as string or object
+        public  string? Coordinates { get; set; } // You may want to format NpgsqlPoint as string or object
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public int OrganizationId { get; set; }

--- a/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/BuildingDto.cs
@@ -16,7 +16,7 @@ namespace BUILD.ING.Dto
         public decimal? TotalArea { get; set; }
         public int? Floors { get; set; }
         public string Description { get; set; }
-        public  string? Coordinates { get; set; } // You may want to format NpgsqlPoint as string or object
+        public string? Coordinates { get; set; } // You may want to format NpgsqlPoint as string or object
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public int OrganizationId { get; set; }

--- a/BitAndBeam/backend/BUILD.ING/Dto/DocumentDto.cs
+++ b/BitAndBeam/backend/BUILD.ING/Dto/DocumentDto.cs
@@ -19,6 +19,7 @@ namespace BUILD.ING.Dto
         public string Metadata { get; set; }
         public string FileName { get; set; }
         public DateTime UploadedAt { get; set; }
-        public string GroupId { get; set; }
+        public int OrganizationId { get; set; }
+
     }
 }

--- a/BitAndBeam/backend/BUILD.ING/Migrations/20250625150952_AddOrganizationIdToDocuments.Designer.cs
+++ b/BitAndBeam/backend/BUILD.ING/Migrations/20250625150952_AddOrganizationIdToDocuments.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BUILD.ING.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Build.ING.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250625150952_AddOrganizationIdToDocuments")]
+    partial class AddOrganizationIdToDocuments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BitAndBeam/backend/BUILD.ING/Migrations/20250625150952_AddOrganizationIdToDocuments.cs
+++ b/BitAndBeam/backend/BUILD.ING/Migrations/20250625150952_AddOrganizationIdToDocuments.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/BitAndBeam/backend/BUILD.ING/Migrations/20250625150952_AddOrganizationIdToDocuments.cs
+++ b/BitAndBeam/backend/BUILD.ING/Migrations/20250625150952_AddOrganizationIdToDocuments.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Build.ING.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationIdToDocuments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupId",
+                table: "Documents");
+
+            migrationBuilder.AddColumn<int>(
+                name: "OrganizationId",
+                table: "Documents",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OrganizationId",
+                table: "Documents");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GroupId",
+                table: "Documents",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/BitAndBeam/backend/BUILD.ING/Models/Building.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/Building.cs
@@ -21,7 +21,6 @@ namespace BUILD.ING.Models
         public NpgsqlPoint? Coordinates { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
-
         public int OrganizationId { get; set; }
         public Organization Organization { get; set; }
         public ICollection<BuildingDocumentRelation> BuildingDocumentRelations { get; set; }

--- a/BitAndBeam/backend/BUILD.ING/Models/Document.cs
+++ b/BitAndBeam/backend/BUILD.ING/Models/Document.cs
@@ -22,7 +22,7 @@ namespace BUILD.ING.Models
         public string Metadata { get; set; }
         public string FileName { get; set; }
         public DateTime UploadedAt { get; set; }
-        public string GroupId { get; set; }
+        public int OrganizationId { get; set; }
         public User Uploader { get; set; }
         public ICollection<DocumentTagRelation> DocumentTagRelations { get; set; }
         public ICollection<DocumentPermission> DocumentPermissions { get; set; }

--- a/BitAndBeam/frontend/src/api/api.ts
+++ b/BitAndBeam/frontend/src/api/api.ts
@@ -200,12 +200,6 @@ export interface BuildingCreateDto {
     'description'?: string | null;
     /**
      * 
-     * @type {number}
-     * @memberof BuildingCreateDto
-     */
-    'organizationId'?: number;
-    /**
-     * 
      * @type {NpgsqlPoint}
      * @memberof BuildingCreateDto
      */
@@ -467,10 +461,10 @@ export interface Document {
     'uploadedAt'?: string;
     /**
      * 
-     * @type {string}
+     * @type {number}
      * @memberof Document
      */
-    'groupId'?: string | null;
+    'organizationId'?: number;
     /**
      * 
      * @type {User}

--- a/BitAndBeam/frontend/src/app/components/create-building/create-building.component.html
+++ b/BitAndBeam/frontend/src/app/components/create-building/create-building.component.html
@@ -60,15 +60,6 @@
 
     <label for="longitude">Longitude:</label>
     <input type="number" id="longitude" [(ngModel)]="building.longitude" name="longitude">
-
-    <label>
-      Organization*:
-      <select [(ngModel)]="building.organizationId" name="organizationId" required>
-        <option [ngValue]="null" disabled selected>Select an organization</option>
-        <option *ngFor="let org of organizations" [ngValue]="org.id">{{ org.name }}</option>
-      </select>
-    </label>
-
     <button type="submit">Create</button>
   </form>
 </div>

--- a/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
+++ b/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
@@ -39,8 +39,8 @@ export class CreateBuildingComponent {
 
   submitForm() {
     if (!this.building.name?.trim() || !this.building.streetName?.trim() || !this.building.houseNumber?.trim() || !this.building.postalCode?.trim()
-      || !this.building.city?.trim() || !this.building.country?.trim() || !this.building.organizationId) {
-      this.errorMessage = 'Name, Address, and Organization are required.';
+      || !this.building.city?.trim() || !this.building.country?.trim() ) {
+      this.errorMessage = 'Name and Address fields are required.';
       return;
     }
 

--- a/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
+++ b/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
@@ -13,8 +13,6 @@ import { Building as ApiBuilding } from '../../../api';
   styleUrls: ['./create-building.component.css']
 })
 export class CreateBuildingComponent {
-  // Hardcoded organizations for now
-
 
   // Initialize the building object
   building: Partial<ApiBuilding> & { latitude?: number; longitude?: number } = {
@@ -28,7 +26,6 @@ export class CreateBuildingComponent {
     totalArea: null,
     floors: null,
     description: '',
-    organizationId: undefined,
     latitude: undefined,
     longitude: undefined
   };

--- a/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
+++ b/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
@@ -60,7 +60,6 @@ export class CreateBuildingComponent {
       totalArea: this.building.totalArea,
       floors: this.building.floors,
       description: this.building.description,
-      organizationId: this.building.organizationId,
       buildingDocumentRelations: [],
       coordinates: coordinates
     };

--- a/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
+++ b/BitAndBeam/frontend/src/app/components/create-building/create-building.component.ts
@@ -14,10 +14,7 @@ import { Building as ApiBuilding } from '../../../api';
 })
 export class CreateBuildingComponent {
   // Hardcoded organizations for now
-  organizations = [
-    {id: 1, name: 'Organization Alpha'},
-    {id: 2, name: 'Organization Beta'}
-  ];
+
 
   // Initialize the building object
   building: Partial<ApiBuilding> & { latitude?: number; longitude?: number } = {
@@ -44,7 +41,7 @@ export class CreateBuildingComponent {
   }
 
   submitForm() {
-    if (!this.building.name?.trim() || !this.building.streetName?.trim() || !this.building.houseNumber?.trim() || !this.building.postalCode?.trim() 
+    if (!this.building.name?.trim() || !this.building.streetName?.trim() || !this.building.houseNumber?.trim() || !this.building.postalCode?.trim()
       || !this.building.city?.trim() || !this.building.country?.trim() || !this.building.organizationId) {
       this.errorMessage = 'Name, Address, and Organization are required.';
       return;


### PR DESCRIPTION
All criteria are met: 


Criterion 1: A user should be assigned to one Organization on creation.
Criterion 2: A user should only be able to access Buildings and Documents from its own Organization. This holds for frontend interaction as well as calling the backend directly.
Criterion 3: The Building form should not contain a field for the Organization. The Building is assigned automatically to the Organization of the user that created it.
Criterion 4: For this project's scope, users cannot create or update Organizations. We limit the project to the two Organizations that are seeded in the database.